### PR TITLE
Update for 2020

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.3.0
+  rev: v3.1.0
   hooks:
     - id: check-yaml
     - id: end-of-file-fixer
     - id: requirements-txt-fixer
     - id: trailing-whitespace
-- repo: https://github.com/willthames/ansible-lint.git
-  rev: v4.1.0
+- repo: https://github.com/ansible/ansible-lint.git
+  rev: v4.3.0a1
   hooks:
     - id: ansible-lint

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ ansible-playbook --inventory localhost, archsible.yml
 * Requirements
   * [Packer](https://www.packer.io)
   * [Vagrant](https://www.vagrantup.com)
-  * [VirtalBox](https://www.virtualbox.org)
+  * [VirtualBox](https://www.virtualbox.org)
 * Build Vagrant box
 
 ```bash

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 callback_whitelist = profile_tasks
+interpreter_python = auto
 retry_files_enabled = false
 roles_path = roles/vendor:roles
 [ssh_connection]

--- a/packer/archsible.yaml
+++ b/packer/archsible.yaml
@@ -1,7 +1,7 @@
 ---
 variables:
-  iso_url: https://mirrors.kernel.org/archlinux/iso/2019.09.01/archlinux-2019.09.01-x86_64.iso
-  iso_checksum_url: https://mirrors.kernel.org/archlinux/iso/2019.09.01/sha1sums.txt
+  iso_url: https://mirrors.kernel.org/archlinux/iso/2020.05.01/archlinux-2020.05.01-x86_64.iso
+  iso_checksum_url: https://mirrors.kernel.org/archlinux/iso/2020.05.01/sha1sums.txt
   iso_checksum_type: sha1
   ssh_timeout: 20m
   country: US
@@ -16,9 +16,9 @@ builders:
   guest_os_type: ArchLinux_64
   guest_additions_mode: disable
   http_directory: packer/http
-  boot_wait: 5s
+  boot_wait: 2s
   boot_command:
-  - <enter><wait10><wait10><wait10><wait10>
+  - <up><up><enter><wait10><wait10><wait10><wait10>
   - 'curl -O "{{ .HTTPIP }}:{{ .HTTPPort }}/enable-ssh.sh"<enter><wait>'
   - sh enable-ssh.sh<enter>
   memory: 1024

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ansible==2.8.4
+ansible==2.9.9
 jmespath

--- a/roles/hardware/virtualbox/tasks/main.yml
+++ b/roles/hardware/virtualbox/tasks/main.yml
@@ -7,7 +7,6 @@
   pacman:
     name:
       - virtualbox-guest-utils
-      - virtualbox-guest-modules-arch
       - nfs-utils
 
 - name: Enable VB guest services

--- a/roles/luks/tasks/main.yml
+++ b/roles/luks/tasks/main.yml
@@ -23,9 +23,7 @@
     '{{ item.item.device }}'
   args:
     stdin: '{{ item.item.passphrase }}'
-    # 304 is false positive:
-    # ansible-lint doesn't know about stdin_add_newline and strip_empty_ends
-    stdin_add_newline: false # noqa 304
+    stdin_add_newline: false
     strip_empty_ends: false
   when: item.rc != 0
   with_items: '{{ _cryptsetup_islucks.results }}'
@@ -49,9 +47,7 @@
      '{{ item.item.name }}'
   args:
     stdin: '{{ item.item.passphrase }}'
-    # 304 is false positive:
-    # ansible-lint doesn't know about stdin_add_newline and strip_empty_ends
-    stdin_add_newline: false # noqa 304
+    stdin_add_newline: false
     strip_empty_ends: false
   when: item.rc != 0
   with_items: '{{ _cryptsetup_isactive.results }}'
@@ -112,9 +108,7 @@
     '{{ item.item.keyfile }}'
   args:
     stdin: '{{ item.item.passphrase }}'
-    # 304 is false positive:
-    # ansible-lint doesn't know about stdin_add_newline and strip_empty_ends
-    stdin_add_newline: false # noqa 304
+    stdin_add_newline: false
     strip_empty_ends: false
   when:
     - item.item.keyfile is defined

--- a/roles/lvm/meta/main.yml
+++ b/roles/lvm/meta/main.yml
@@ -58,5 +58,6 @@ dependencies:
       filesystems_progs: '{{
         lvm_volumes
           | map(attribute="lvs") | flatten(levels=1)
-          | map(attribute="fstype") | unique
+          | map(attribute="fstype") | list
+          + _lvm_filesystems_progs | unique
       }}'

--- a/roles/lvm/vars/main.yml
+++ b/roles/lvm/vars/main.yml
@@ -1,0 +1,4 @@
+---
+# vars file for lvm
+
+_lvm_filesystems_progs: [lvm]

--- a/roles/network/connman/defaults/main.yml
+++ b/roles/network/connman/defaults/main.yml
@@ -6,7 +6,7 @@ connman_conf:
     settings:
       # https://wiki.archlinux.org/index.php/ConnMan#Avoid_changing_the_hostname
       - option: AllowHostnameUpdates
-        value: false
+        value: 'false'
       # https://wiki.archlinux.org/index.php/ConnMan#Prefer_ethernet_to_wireless
       - option: PreferredTechnologies
         value: ethernet,wifi


### PR DESCRIPTION
* Upgrade pre-commit hooks
* Upgrade Ansible to 2.9.9
* Update Arch linux iso URL
* Arch iso default boot entry has changed to UEFI Shell,
  need to press up arrow key twice to boot archiso
* Ensure `lvm2` package is installed when running `lvm` role
* `virtualbox-guest-modules-arch` is now included in the `core/linux`
  package